### PR TITLE
fix: doc not found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![doc=include_str!("../README.md")]
+#![doc=include_str!("../README.MD")]
 pub use tokio_scheduler_types::errors;
 pub mod job_consumer;
 pub mod job_hook;


### PR DESCRIPTION
This pull request includes a small change to the `src/lib.rs` file. The change corrects the file extension in the `include_str!` macro to ensure proper inclusion of the README documentation.

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L2-R2): Changed file extension from lowercase to uppercase in the `include_str!` macro to correctly include the README documentation.