### PR TITLE
bump: version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-scheduler-rs"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "Yet Another JobScheduler written with tokio runtime, automatic retry, hook and custom storage supported."
 license = "MIT"


### PR DESCRIPTION
This pull request includes a small change to the `Cargo.toml` file. The change updates the version of the `tokio-scheduler-rs` package from "2.0.0" to "2.0.1".