### PR TITLE
fix push action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ on:
   push:
     tags:
       - '*'
-  
+
 jobs:
   check:
     name: Check and Test
@@ -20,10 +20,20 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Publish to crates.io
-      run: |
-        cargo login ${{ secrets.CRATES_TOKEN }}
-        cargo publish -v
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Push types to crates.io
+        working-directory: tokio-scheduler-types
+        run: |
+          cargo login ${{ secrets.CRATES_TOKEN }}
+          cargo publish -v
+      - name: Push macro to crates.io
+        working-directory: tokio-scheduler-macro
+        run: |
+          cargo login ${{ secrets.CRATES_TOKEN }}
+          cargo publish -v
+      - name: Publish to crates.io
+        run: |
+          cargo login ${{ secrets.CRATES_TOKEN }}
+          cargo publish -v
     

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ anyhow = "^1"
 parking_lot = "^0"
 tracing = "^0"
 tokio-util = "^0"
-tokio-scheduler-types = { path = 'tokio-scheduler-types' }
-tokio-scheduler-macro = { path = 'tokio-scheduler-macro' }
+tokio-scheduler-types = { version = "^2" }
+tokio-scheduler-macro = { version = "^2" }
 inventory = "^0"
 
 [dev-dependencies]

--- a/tokio-scheduler-macro/Cargo.toml
+++ b/tokio-scheduler-macro/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 edition = "2021"
 description = "Macros for tokio-scheduler-rs"
 license = "MIT"
+readme = "README.MD"
 
 [lib]
 proc-macro = true
@@ -11,7 +12,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "^2", features = ["full"] }
 quote = "^1"
-tokio-scheduler-types = { path = '../tokio-scheduler-types' }
+tokio-scheduler-types = { version = "^2" }
 convert_case = { version = "^0" }
 proc-macro2 = "^1"
 

--- a/tokio-scheduler-macro/README.MD
+++ b/tokio-scheduler-macro/README.MD
@@ -1,0 +1,3 @@
+# tokio-scheduler-macro
+
+This crate provides a procedural macro for the tokio-scheduler-rs ecosystem.

--- a/tokio-scheduler-types/Cargo.toml
+++ b/tokio-scheduler-types/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 edition = "2021"
 description = "Types for tokio-scheduler-rs"
 license = "MIT"
+readme = "README.MD"
 
 [dependencies]
 tokio = { version = "^1", features = [] }

--- a/tokio-scheduler-types/README.MD
+++ b/tokio-scheduler-types/README.MD
@@ -1,0 +1,3 @@
+# tokio-scheduler-types
+
+This crate provides the core types and traits for the tokio-scheduler-rs ecosystem.


### PR DESCRIPTION
This pull request includes several important changes to the `tokio-scheduler` project, focusing on publishing crates to `crates.io`, updating dependencies, and adding README files for better documentation.

### Publishing crates to `crates.io`:
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R25-R34): Added steps to push both `tokio-scheduler-types` and `tokio-scheduler-macro` crates to `crates.io` during the workflow execution.

### Dependency updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L28-R29): Updated the dependencies for `tokio-scheduler-types` and `tokio-scheduler-macro` to use version `^2` instead of local paths.
* [`tokio-scheduler-macro/Cargo.toml`](diffhunk://#diff-4e63e8ab11688c9bc2a61bd6536ff00d74d660f523b71657cb460cba331f32c3R7-R15): Updated the dependency for `tokio-scheduler-types` to version `^2`.
* [`tokio-scheduler-types/Cargo.toml`](diffhunk://#diff-a4d967af8a0f202ab163fc4d60ce15d7ce091f8ccd06918d4ee75a886c7fbc58R7): Added a `readme` field pointing to `README.MD`.

### Documentation improvements:
* [`tokio-scheduler-macro/README.MD`](diffhunk://#diff-681740733b068633b89125b832dc7c875da8698efd7a432ddbe36ad6c6de443aR1-R3): Added a README file describing the `tokio-scheduler-macro` crate.
* [`tokio-scheduler-types/README.MD`](diffhunk://#diff-4c8b7db78a54378bad3f8faa47c4be67864a17302dd6b4fefff8a4dec3fbd78bR1-R3): Added a README file describing the `tokio-scheduler-types` crate.